### PR TITLE
Dockerfile: Change CMD to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY config.yml /
 # use non-root user
 USER appuser
 
-CMD ["/go/bin/pagerbot"]
+ENTRYPOINT ["/go/bin/pagerbot"]


### PR DESCRIPTION
Using ENTRYPOINT makes argument passing simpler (In my use case, passing the config file through flag) since `/go/bin/pagerbot` should always be the command to be executed when the container starts. This recommendation is based on https://stackoverflow.com/questions/21553353/what-is-the-difference-between-cmd-and-entrypoint-in-a-dockerfile