### PR TITLE
Fix duplicate oncall

### DIFF
--- a/internal/slack/postMessage.go
+++ b/internal/slack/postMessage.go
@@ -9,6 +9,6 @@ func (a *Api) PostMessage(channel string, message string) error {
 	mp.Username = "Pagerduty Bot"
 	mp.LinkNames = 1
 
-	_, _, err := a.api.PostMessage(channel, message, mp)
+	_, _, err := a.api.PostMessage(channel, slack.MsgOptionText(message, false), slack.MsgOptionPostMessageParameters(mp))
 	return err
 }

--- a/internal/updater/updateGroups.go
+++ b/internal/updater/updateGroups.go
@@ -2,13 +2,14 @@ package updater
 
 import (
 	"fmt"
-	"github.com/karlkfi/pagerbot/internal/config"
-	"github.com/karlkfi/pagerbot/internal/pagerduty"
-	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/karlkfi/pagerbot/internal/config"
+	"github.com/karlkfi/pagerbot/internal/pagerduty"
+	log "github.com/sirupsen/logrus"
 )
 
 // Ensure all the slack groups are up to date
@@ -49,7 +50,9 @@ func (u *Updater) updateGroups() {
 					log.WithFields(lf).Warning("Could not find user with ID")
 					continue
 				}
-				currentUsers = append(currentUsers, usr)
+				if !userIn(currentUsers, usr.SlackId) {
+					currentUsers = append(currentUsers, usr)
+				}
 			}
 		}
 
@@ -99,4 +102,13 @@ func (u *Updater) updateGroups() {
 			log.WithFields(lf).Info("Group members unchanged")
 		}
 	}
+}
+
+func userIn(slice []*User, userSlackID string) bool {
+	for _, user := range slice {
+		if user.SlackId == userSlackID {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
If The same user is oncall for both Primary and Secondary, they'll show up
twice in currentUsers. But the Pagerduty API only returns the user once, so the
DeepEquals fails because `["UserA"] != ["UserA", "UserA"]`.