### PR TITLE
Add user dedupe when in multiple schedules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,6 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 // indirect
-	github.com/mitchellh/gox v0.4.0 // indirect
-	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/nlopes/slack v0.4.0
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/sirupsen/logrus v1.2.0
@@ -19,3 +17,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20160301204022-a83829b6f129
 )
+
+go 1.13

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -2,8 +2,8 @@ package slack
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"github.com/nlopes/slack"
+	log "github.com/sirupsen/logrus"
 )
 
 type Api struct {

--- a/internal/updater/updateGroups.go
+++ b/internal/updater/updateGroups.go
@@ -2,13 +2,14 @@ package updater
 
 import (
 	"fmt"
-	"github.com/karlkfi/pagerbot/internal/config"
-	"github.com/karlkfi/pagerbot/internal/pagerduty"
-	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/karlkfi/pagerbot/internal/config"
+	"github.com/karlkfi/pagerbot/internal/pagerduty"
+	log "github.com/sirupsen/logrus"
 )
 
 // Ensure all the slack groups are up to date
@@ -49,7 +50,10 @@ func (u *Updater) updateGroups() {
 					log.WithFields(lf).Warning("Could not find user with ID")
 					continue
 				}
-				currentUsers = append(currentUsers, usr)
+				// don't add duplicates (same user in multiple schedules concurrently)
+				if !contains(currentUsers, usr) {
+					currentUsers = append(currentUsers, usr)
+				}
 			}
 		}
 
@@ -99,4 +103,13 @@ func (u *Updater) updateGroups() {
 			log.WithFields(lf).Info("Group members unchanged")
 		}
 	}
+}
+
+func contains(s []*User, e *User) bool {
+	for _, a := range s {
+		if a.PagerdutyId == e.PagerdutyId {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Pagerbot can get into a slack spam loop when a single user is in multiple concurrent schedules for the same service. Deduping the current users list should (hopefully) avoid this edge case.